### PR TITLE
feat(db): создан слой для работы с данными

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,17 @@
             <artifactId>lombok</artifactId>
             <version>1.18.38</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+        </dependency>
     </dependencies>
 
 

--- a/src/main/java/project/model/ApiLog.java
+++ b/src/main/java/project/model/ApiLog.java
@@ -1,0 +1,28 @@
+package project.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Setter
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "api_logs")
+public class ApiLog {
+    @Id
+    private long id;
+
+    private String requestBody;
+
+    private String responseBody;
+
+    private LocalDate createdAt;
+}

--- a/src/main/java/resources/application.yml
+++ b/src/main/java/resources/application.yml
@@ -1,0 +1,17 @@
+server:
+  port: 8090
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/postgres
+    username: postgres
+    password: postgres
+    driver-class-name: org.postgres.sql.drive
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+
+  liquibase:
+    change-log: classpath:/liquibase/db.changelog.yml
+    enabled: true

--- a/src/main/java/resources/liquibase/db.changelog.yml
+++ b/src/main/java/resources/liquibase/db.changelog.yml
@@ -1,0 +1,3 @@
+databaseChangeLog:
+  - includeAll:
+      path: liquibase/migration/

--- a/src/main/java/resources/liquibase/migration/V1__init.sql
+++ b/src/main/java/resources/liquibase/migration/V1__init.sql
@@ -1,0 +1,12 @@
+CREATE TABLE api_logs (
+                          id BIGSERIAL PRIMARY KEY,
+                          request_body TEXT,
+                          response_body TEXT,
+                          created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE days (
+                      id BIGSERIAL PRIMARY KEY,
+                      date DATE NOT NULL UNIQUE,
+                      day_type VARCHAR(255) NOT NULL
+);


### PR DESCRIPTION
- В pom.xml добавлены зависимости `postgresql` и `liquibase-core`.
- В `application.yml` настроено подключение к локальной базе данных PostgreSQL.
- Создана структура миграций Liquibase на основе SQL с главным файлом `db.changelog.yml`.
- Создана начальная миграция `V1_init.sql`, которая создает таблицы `api_logs` и `days`.
- Добавлена JPA-сущность `ApiLog.java` для маппинга на таблицу `api_logs`.